### PR TITLE
fix(deps): bump meow from 3.x.x to 9.x.x [security] CVE-2021-33623

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "get-stdin": "^5.0.1",
     "indent-string": "^3.0.0",
     "longest": "^2.0.0",
-    "meow": "^3.3.0"
+    "meow": "^9.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
This should fix https://github.com/advisories/GHSA-7p7h-4mm5-852v vulnerabilities downstream in any pkgs that use this.

Bump to `meow@9` (and not 10) due to ESM compat. Fix to avoid using `meow@3.7.0` which pulls `trim-newlines@1.0.0`.

Tested locally with example from README, the cli works fine without any breaking changes.