### PR TITLE
Updated meow dependency because of high severity ReDoS warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "get-stdin": "^5.0.1",
     "indent-string": "^3.0.0",
     "longest": "^2.0.0",
-    "meow": "^9.0.0"
+    "meow": "^10.0.1"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
I am anoyed by two ReDoS warnings in my audit, please fix.
`all 4 tests passed`